### PR TITLE
Set default value for Ensure parameter

### DIFF
--- a/DscResources/MSFT_xSmbShare/MSFT_xSmbShare.psm1
+++ b/DscResources/MSFT_xSmbShare/MSFT_xSmbShare.psm1
@@ -161,7 +161,7 @@ function Set-TargetResource
 
         [ValidateSet("Present","Absent")]
         [System.String]
-        $Ensure
+        $Ensure = 'Present'
     )
 
     $psboundparameters.Remove("Debug")
@@ -312,7 +312,7 @@ function Test-TargetResource
 
         [ValidateSet("Present","Absent")]
         [System.String]
-        $Ensure
+        $Ensure = 'Present'
     )
     $testResult = $false;
     $share = Get-TargetResource -Name $Name -Path $Path -ErrorAction SilentlyContinue -ErrorVariable ev

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Admin shares, default shares, IPC$ share are examples.
 
 ### Unreleased
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
+* Added default value of "Present" for the Ensure parameter.  (Note:  due to how the module's logic is written, this is a breaking change; DSC configs that did not specify a value for Ensure would have behaved as though it were set to Present in the Test-TargetResource function, but to absent in Set-TargetResource, removing the share instead of creating it.)
 
 ### 1.1.0.0
 * Fixed bug in xSmbShare resource which was causing Test-TargetResource to return false negatives when more than three parameters were specified.


### PR DESCRIPTION
By convention, DSC resources' `Ensure` parameter should default to `Present`.  This resource had no default value assigned for `Ensure`, and the way the code was written, it was effectively defaulting to `Present` for the `Test-TargetResource` function, but to `Absent` for the `Set-TargetResource` function.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsmbshare/12)

<!-- Reviewable:end -->
